### PR TITLE
Fix time token HMAC strength

### DIFF
--- a/core/sum_core/forms/services.py
+++ b/core/sum_core/forms/services.py
@@ -139,7 +139,7 @@ def _sign_timestamp(timestamp: str) -> str:
     """Create HMAC signature for a timestamp."""
     key = settings.SECRET_KEY.encode()
     message = timestamp.encode()
-    return hmac.new(key, message, hashlib.sha256).hexdigest()[:16]
+    return hmac.new(key, message, hashlib.sha256).hexdigest()
 
 
 def check_timing(

--- a/tests/forms/test_spam_protection.py
+++ b/tests/forms/test_spam_protection.py
@@ -143,7 +143,7 @@ class TestTimeTokenGeneration:
         parts = token.split(":")
         assert len(parts) == 2
         assert parts[0].isdigit()
-        assert len(parts[1]) == 16  # Truncated HMAC
+        assert len(parts[1]) == 64  # Full SHA-256 HMAC hexdigest
 
     def test_generates_unique_tokens(self):
         """Each call should generate a unique signature timing."""


### PR DESCRIPTION
## Summary\n- use full SHA-256 HMAC for time tokens\n- update time token generation test to match new signature length\n\n## Testing\n- not run (pytest not available in environment)\n\nCloses #31