### PR TITLE
docs(THEME-039): add followup report

### DIFF
--- a/THEME-039_followup.md
+++ b/THEME-039_followup.md
@@ -1,0 +1,15 @@
+Summary:
+- Verified ManifestoBlock is already implemented in core blocks, registered in PageStreamBlock, and documented.
+- Confirmed Theme A override template and tests exist and match acceptance criteria.
+
+Files modified/created:
+- THEME-039_followup.md
+
+Test results:
+- Not run (no code changes required).
+
+Decisions / blockers:
+- No code changes needed; functionality already present on `develop`.
+
+Doc updates:
+- None.


### PR DESCRIPTION
## Summary\n- add THEME-039 followup report noting ManifestoBlock work is already present on develop\n\n## Testing\n- not run (no code changes)\n\nCloses #78