### PR TITLE
Release v0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.5.2] - 2025-12-24
+### Fixed
+- Packaging: limit setuptools discovery to `sum_core` (exclude boilerplate) so pip installs from git tags succeed.
+
 ## [v0.5.1] - 2025-12-24
 ### Fixed
 - Packaging: set PEP 508-compliant project name (`sum-core`) so pip installs from git tags work again.

--- a/boilerplate/requirements.txt
+++ b/boilerplate/requirements.txt
@@ -7,7 +7,7 @@
 # and uncomment the editable install:
 #   -e ../../core
 
-sum-core @ git+https://github.com/markashton480/sum-core.git@v0.5.1#subdirectory=core
+sum-core @ git+https://github.com/markashton480/sum-core.git@v0.5.2#subdirectory=core
 
 # PostgreSQL driver for production deployments
 psycopg[binary]>=3.2,<4

--- a/cli/sum_cli/boilerplate/requirements.txt
+++ b/cli/sum_cli/boilerplate/requirements.txt
@@ -7,7 +7,7 @@
 # and uncomment the editable install:
 #   -e ../../core
 
-sum-core @ git+https://github.com/markashton480/sum-core.git@v0.5.1#subdirectory=core
+sum-core @ git+https://github.com/markashton480/sum-core.git@v0.5.2#subdirectory=core
 
 # PostgreSQL driver for production deployments
 psycopg[binary]>=3.2,<4

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sum-core"
-version = "0.5.1"
+version = "0.5.2"
 description = "Shared core package for SUM client websites"
 requires-python = ">=3.12"
 dependencies = [

--- a/core/sum_core/__init__.py
+++ b/core/sum_core/__init__.py
@@ -8,4 +8,4 @@ Dependencies: None (standard library only).
 
 __all__ = ["__version__"]
 
-__version__: str = "0.5.1"
+__version__: str = "0.5.2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,10 +4,24 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sum-core"
-version = "0.5.1"
+version = "0.5.2"
 description = "SUM core package and tooling (platform monorepo)"
 requires-python = ">=3.12"
 dependencies = []
+
+[tool.setuptools]
+package-dir = {"" = "core"}
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["core"]
+include = ["sum_core*"]
+
+[tool.setuptools.package-data]
+sum_core = [
+    "templates/**/*.html",
+    "static/**/*",
+]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Release v0.5.2

### Changes
- Packaging: restrict setuptools discovery to  so pip installs from git tags exclude boilerplate and build correctly.
- Version bump to v0.5.2 with boilerplate pin updates.

### Checklist
- [x] ruff check . --config pyproject.toml
All checks passed!
mypy core cli tests passed
- [x] Boilerplate pinned to v0.5.2
- [x] CHANGELOG.md updated
- [ ] Review and approve
- [ ] Squash and merge
