### PR TITLE
Cookie banner include + a11y baseline + theme contract

### DIFF
--- a/core/sum_core/templates/sum_core/includes/cookie_banner.html
+++ b/core/sum_core/templates/sum_core/includes/cookie_banner.html
@@ -1,0 +1,31 @@
+{% load branding_tags wagtailcore_tags %}
+{% get_site_settings as site_settings %}
+
+{% if site_settings.cookie_banner_enabled %}
+  <aside class="cookie-banner" aria-label="Cookie preferences">
+    <div class="cookie-banner__content">
+      <p class="cookie-banner__message">
+        We use cookies to improve your experience and analyze site traffic.
+      </p>
+      {% if site_settings.privacy_policy_page or site_settings.cookie_policy_page %}
+        <p class="cookie-banner__links">
+          {% if site_settings.privacy_policy_page %}
+            <a href="{% pageurl site_settings.privacy_policy_page %}">
+              Privacy Policy
+            </a>
+          {% endif %}
+          {% if site_settings.cookie_policy_page %}
+            <a href="{% pageurl site_settings.cookie_policy_page %}">
+              Cookie Policy
+            </a>
+          {% endif %}
+        </p>
+      {% endif %}
+    </div>
+    <div class="cookie-banner__actions">
+      <button type="button" data-cookie-consent="accept">Accept</button>
+      <button type="button" data-cookie-consent="reject">Reject</button>
+    </div>
+    <p class="cookie-banner__status" aria-live="polite"></p>
+  </aside>
+{% endif %}

--- a/core/sum_core/templates/sum_core/includes/footer.html
+++ b/core/sum_core/templates/sum_core/includes/footer.html
@@ -108,10 +108,21 @@
             </div>
         </div>
 
-        {# Copyright #}
-        {% if footer.copyright.rendered %}
+        {# Copyright / Cookie Controls #}
+        {% if footer.copyright.rendered or site_settings.cookie_banner_enabled %}
             <div class="footer__bottom">
-                <p class="footer__copyright">{{ footer.copyright.rendered }}</p>
+                {% if footer.copyright.rendered %}
+                    <p class="footer__copyright">{{ footer.copyright.rendered }}</p>
+                {% endif %}
+                {% if site_settings.cookie_banner_enabled %}
+                    <a
+                        class="footer__link footer__link--cookies"
+                        href="#"
+                        data-cookie-consent="manage"
+                    >
+                        Manage cookies
+                    </a>
+                {% endif %}
             </div>
         {% endif %}
     </div>

--- a/core/sum_core/templates/theme/base.html
+++ b/core/sum_core/templates/theme/base.html
@@ -41,6 +41,8 @@
         {% block content %}{% endblock %}
     </main>
 
+    {% include "sum_core/includes/cookie_banner.html" %}
+
     {% include "theme/includes/footer.html" %}
 
     <!-- Sticky CTA (Mobile) -->


### PR DESCRIPTION
Summary:
- add cookie banner include and default markup with consent hooks
- add manage cookies entry point in footer

Testing:
- make lint
- make test

Closes #134