### PR TITLE
chore(ci): expand branch triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,20 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches:
+      - main
+      - develop
+      - release/*
+      - feature/*
+      - task/*
+      - fix/*
+      - feat/*
   pull_request:
-    branches: [main, develop]
+    branches:
+      - main
+      - develop
+      - release/*
+      - feature/*
   # Enable manual workflow dispatch for debugging/ad-hoc runs
   workflow_dispatch:
 


### PR DESCRIPTION
Bring ci.yml branch triggers in line with branch protection. Agent tooling/workflow files already exist on develop, so this PR only updates ci.yml.