### PR TITLE
fix(ci): auto-close issues on non-default merges

### DIFF
--- a/.github/workflows/issue-auto-close.yml
+++ b/.github/workflows/issue-auto-close.yml
@@ -1,0 +1,47 @@
+name: Auto-close Issues on Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+      - feature/*
+      - release/*
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-linked:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Close linked issues
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request.title || "";
+            const body = context.payload.pull_request.body || "";
+            const text = `${title}\n${body}`;
+            const regex = /(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#(\d+)/gi;
+            const matches = [...text.matchAll(regex)];
+            const issueNumbers = [...new Set(matches.map(match => Number(match[3])))]
+              .filter(number => Number.isInteger(number));
+
+            if (issueNumbers.length === 0) {
+              core.info("No closing keywords found in PR title/body.");
+              return;
+            }
+
+            for (const issue_number of issueNumbers) {
+              core.info(`Closing issue #${issue_number}`);
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number,
+                state: "closed",
+              });
+            }


### PR DESCRIPTION
## Summary\n- close linked issues when PRs merge into develop/feature/release branches\n\n## Testing\n- not run (CI-only change)\n\nCloses #243