### PR TITLE
fix(ci): sync claude workflow with default branch

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -11,11 +11,10 @@ concurrency:
 
 jobs:
   claude-review:
-    # Skip draft PRs and release/hotfix PRs (those get audit instead)
+    # Skip draft PRs and release PRs (those get audit instead)
     if: |
       github.event.pull_request.draft == false &&
       !startsWith(github.head_ref, 'release/') &&
-      !startsWith(github.head_ref, 'hotfix/') &&
       github.head_ref != 'develop'
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary\n- align release branch claude-code-review workflow with default branch\n\n## Testing\n- not run (CI-only change)\n\nCloses #244