### PR TITLE
Address review feedback items 3-9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
             echo "docs_ci_only=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          allowed_regex='^(docs/|\\.github/|\\.agent/|\\.claude/|AGENTS\\.md|CLAUDE\\.md|README\\.md)'
+          allowed_regex='^(docs/|\\.agent/|\\.claude/|AGENTS\\.md|CLAUDE\\.md|README\\.md)'
           docs_ci_only=true
 
           while IFS= read -r file; do

--- a/cli/sum/cli.py
+++ b/cli/sum/cli.py
@@ -1,3 +1,5 @@
+"""Command-line entrypoint wiring for the SUM platform CLI."""
+
 from __future__ import annotations
 
 import click

--- a/cli/sum/commands/check.py
+++ b/cli/sum/commands/check.py
@@ -1,3 +1,5 @@
+"""Check command for validating SUM project readiness."""
+
 from __future__ import annotations
 
 import sys
@@ -39,7 +41,11 @@ def _virtualenv_check(validator: ProjectValidator) -> ValidationResult:
 
 
 def run_enhanced_checks(project_path: Path, mode: ExecutionMode) -> None:
-    """Run enhanced validation checks."""
+    """Run enhanced validation checks.
+
+    Example:
+        run_enhanced_checks(Path(\"clients/demo\"), ExecutionMode.STANDALONE)
+    """
     validator = ProjectValidator(project_path, mode)
 
     checks: list[tuple[str, Callable[[], ValidationResult]]] = [

--- a/cli/sum/commands/run.py
+++ b/cli/sum/commands/run.py
@@ -1,3 +1,5 @@
+"""Run command for starting SUM projects with virtualenv awareness."""
+
 from __future__ import annotations
 
 import os
@@ -16,7 +18,11 @@ from cli.sum.utils.environment import (
 
 
 def find_available_port(start_port: int = 8000, max_attempts: int = 10) -> int:
-    """Find an available port starting from start_port."""
+    """Find an available port starting from start_port.
+
+    Example:
+        find_available_port(8000, max_attempts=5)
+    """
     for port in range(start_port, start_port + max_attempts):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
             try:

--- a/cli/sum/setup/deps.py
+++ b/cli/sum/setup/deps.py
@@ -40,7 +40,8 @@ class DependencyManager:
             raise DependencyError(f"Virtualenv python not found at {python}") from exc
         except subprocess.CalledProcessError as exc:
             OutputFormatter.error("pip install failed")
-            raise DependencyError(f"pip install failed: {exc.stderr}") from exc
+            details = exc.stderr or exc.stdout or "Unknown error"
+            raise DependencyError(f"pip install failed: {details}") from exc
 
         OutputFormatter.success("Dependencies installed")
 

--- a/cli/sum/setup/venv.py
+++ b/cli/sum/setup/venv.py
@@ -29,8 +29,9 @@ class VenvManager:
             )
         except subprocess.CalledProcessError as exc:
             OutputFormatter.error("Failed to create virtualenv")
+            details = exc.stderr or exc.stdout or "Unknown error"
             raise VenvError(
-                f"Failed to create virtualenv at {venv_path}: {exc.stderr}"
+                f"Failed to create virtualenv at {venv_path}: {details}"
             ) from exc
 
         OutputFormatter.success(f"Virtualenv created at {venv_path}")

--- a/cli/sum/utils/output.py
+++ b/cli/sum/utils/output.py
@@ -7,44 +7,56 @@ class OutputFormatter:
     """Formatting helpers for CLI output."""
 
     @staticmethod
-    def progress(step: int, total: int, message: str, status: str = "running") -> str:
+    def progress(
+        step: int, total: int, message: str, status: str = "running", emit: bool = True
+    ) -> str:
         """Format, print, and return a progress line for a multi-step operation."""
         line = f"⏳ [{step}/{total}] {status}: {message}"
-        print(line)
+        if emit:
+            print(line)
         return line
 
     @staticmethod
-    def success(message: str) -> str:
+    def success(message: str, emit: bool = True) -> str:
         """Format, print, and return a success message string."""
         line = f"✅ {message}"
-        print(line)
+        if emit:
+            print(line)
         return line
 
     @staticmethod
-    def error(message: str) -> str:
+    def error(message: str, emit: bool = True) -> str:
         """Format, print, and return an error message string."""
         line = f"❌ {message}"
-        print(line)
+        if emit:
+            print(line)
         return line
 
     @staticmethod
-    def info(message: str) -> str:
+    def info(message: str, emit: bool = True) -> str:
         """Format, print, and return an informational message string."""
         line = f"ℹ {message}"
-        print(line)
+        if emit:
+            print(line)
         return line
 
     @staticmethod
-    def summary(project_name: str, data: Mapping[str, str]) -> str:
-        """Format, print, and return a formatted summary block for a project."""
+    def summary(project_name: str, data: Mapping[str, str], emit: bool = True) -> str:
+        """Format, print, and return a formatted summary block for a project.
+
+        Password values are intentionally omitted from the output for safety.
+        """
         lines = [
             "📋 Summary",
             "--------------------",
             f"🏷️  Project: {project_name}",
         ]
         for key, value in data.items():
+            if key.lower() == "password":
+                continue
             lines.append(f"✅ {key}: {value}")
         lines.append("--------------------")
         output = "\n".join(lines)
-        print(output)
+        if emit:
+            print(output)
         return output

--- a/cli/tests/test_orchestrator.py
+++ b/cli/tests/test_orchestrator.py
@@ -33,7 +33,7 @@ def test_build_step_list_full_setup(tmp_project_path: Path) -> None:
     orchestrator = SetupOrchestrator(tmp_project_path, ExecutionMode.STANDALONE)
 
     steps = orchestrator._build_step_list(config)
-    step_names = [name for name, _ in steps]
+    step_names = [name.value for name, _ in steps]
 
     assert "Scaffolding structure" in step_names
     assert "Validating structure" in step_names
@@ -51,7 +51,7 @@ def test_build_step_list_quick_mode(tmp_project_path: Path) -> None:
     orchestrator = SetupOrchestrator(tmp_project_path, ExecutionMode.STANDALONE)
 
     steps = orchestrator._build_step_list(config)
-    step_names = [name for name, _ in steps]
+    step_names = [name.value for name, _ in steps]
 
     assert len(steps) == 4
     assert "Scaffolding structure" in step_names
@@ -69,7 +69,7 @@ def test_build_step_list_skip_venv(tmp_project_path: Path) -> None:
     orchestrator = SetupOrchestrator(tmp_project_path, ExecutionMode.STANDALONE)
 
     steps = orchestrator._build_step_list(config)
-    step_names = [name for name, _ in steps]
+    step_names = [name.value for name, _ in steps]
 
     assert "Creating virtualenv" not in step_names
     assert "Installing dependencies" not in step_names
@@ -82,7 +82,7 @@ def test_build_step_list_skip_migrations(tmp_project_path: Path) -> None:
     orchestrator = SetupOrchestrator(tmp_project_path, ExecutionMode.STANDALONE)
 
     steps = orchestrator._build_step_list(config)
-    step_names = [name for name, _ in steps]
+    step_names = [name.value for name, _ in steps]
 
     assert "Running migrations" not in step_names
     assert "Creating virtualenv" in step_names
@@ -95,7 +95,7 @@ def test_build_step_list_skip_seed(tmp_project_path: Path) -> None:
     orchestrator = SetupOrchestrator(tmp_project_path, ExecutionMode.STANDALONE)
 
     steps = orchestrator._build_step_list(config)
-    step_names = [name for name, _ in steps]
+    step_names = [name.value for name, _ in steps]
 
     assert "Seeding homepage" not in step_names
     assert "Running migrations" in step_names
@@ -108,7 +108,7 @@ def test_build_step_list_skip_superuser(tmp_project_path: Path) -> None:
     orchestrator = SetupOrchestrator(tmp_project_path, ExecutionMode.STANDALONE)
 
     steps = orchestrator._build_step_list(config)
-    step_names = [name for name, _ in steps]
+    step_names = [name.value for name, _ in steps]
 
     assert "Creating superuser" not in step_names
     assert "Seeding homepage" in step_names
@@ -120,7 +120,7 @@ def test_build_step_list_with_server(tmp_project_path: Path) -> None:
     orchestrator = SetupOrchestrator(tmp_project_path, ExecutionMode.STANDALONE)
 
     steps = orchestrator._build_step_list(config)
-    step_names = [name for name, _ in steps]
+    step_names = [name.value for name, _ in steps]
 
     assert "Starting server" in step_names
     assert step_names[-1] == "Starting server"  # Should be last step

--- a/cli/tests/test_output.py
+++ b/cli/tests/test_output.py
@@ -40,3 +40,23 @@ def test_summary_output(capsys) -> None:
     assert "🏷️  Project: demo-project" in captured.out
     assert "✅ Location: /tmp/demo" in captured.out
     assert "✅ Status: ready" in captured.out
+
+
+def test_summary_omits_sensitive_fields(capsys) -> None:
+    OutputFormatter.summary(
+        "demo-project",
+        {
+            "password": "secret",
+            "Location": "/tmp/demo",
+        },
+    )
+    captured = capsys.readouterr()
+    assert "secret" not in captured.out
+    assert "✅ Location: /tmp/demo" in captured.out
+
+
+def test_output_can_be_silent(capsys) -> None:
+    message = OutputFormatter.success("quiet success", emit=False)
+    captured = capsys.readouterr()
+    assert message == "✅ quiet success"
+    assert captured.out == ""


### PR DESCRIPTION
Implements Claude review suggestions #3-9 for CLI v2:

- CI skip filter no longer bypasses tests for .github changes
- Hide password in summary output; OutputFormatter methods support silent mode
- Consistent subprocess error details using stderr/stdout fallback
- Setup step names use a typed enum to avoid fragile string matching
- Added module-level docstrings/examples for CLI entrypoints and commands
- Tests updated for OutputFormatter behavior and enum-based steps

Tests: .venv/bin/python -m pytest cli/tests/test_output.py cli/tests/test_orchestrator.py -q