### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.6.0] - 2025-12-28
+### Added
+- See Version Declaration #190 for scoped changes; finalize during release audit.
+
 ## [v0.5.3] - 2025-12-25
 ### Changed
 - Sync staging now defaults to `/tmp/sum-core-sync` to avoid accidental gitlinks; release docs updated.

--- a/boilerplate/requirements.txt
+++ b/boilerplate/requirements.txt
@@ -7,7 +7,7 @@
 # and uncomment the editable install:
 #   -e ../../core
 
-sum-core @ git+https://github.com/markashton480/sum-core.git@v0.5.3#subdirectory=core
+sum-core @ git+https://github.com/markashton480/sum-core.git@v0.6.0#subdirectory=core
 
 # PostgreSQL driver for production deployments
 psycopg[binary]>=3.2,<4

--- a/cli/sum_cli/boilerplate/requirements.txt
+++ b/cli/sum_cli/boilerplate/requirements.txt
@@ -7,7 +7,7 @@
 # and uncomment the editable install:
 #   -e ../../core
 
-sum-core @ git+https://github.com/markashton480/sum-core.git@v0.5.3#subdirectory=core
+sum-core @ git+https://github.com/markashton480/sum-core.git@v0.6.0#subdirectory=core
 
 # PostgreSQL driver for production deployments
 psycopg[binary]>=3.2,<4

--- a/core/pyproject.toml
+++ b/core/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sum-core"
-version = "0.5.3"
+version = "0.6.0"
 description = "Shared core package for SUM client websites"
 requires-python = ">=3.12"
 dependencies = [

--- a/core/sum_core/__init__.py
+++ b/core/sum_core/__init__.py
@@ -8,4 +8,4 @@ Dependencies: None (standard library only).
 
 __all__ = ["__version__"]
 
-__version__: str = "0.5.3"
+__version__: str = "0.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sum-core"
-version = "0.5.3"
+version = "0.6.0"
 description = "SUM core package and tooling (platform monorepo)"
 requires-python = ">=3.12"
 dependencies = []


### PR DESCRIPTION
## Summary
- bump version metadata to 0.6.0
- update boilerplate pins to v0.6.0
- add v0.6.0 changelog header

## Testing
- not run (version/pin updates only)
