### PR TITLE
fix(boilerplate): unblock production seeding + add gunicorn/redis

### DIFF
--- a/boilerplate/project_name/home/management/commands/seed_sage_stone.py
+++ b/boilerplate/project_name/home/management/commands/seed_sage_stone.py
@@ -14,7 +14,10 @@ from typing import Any, TypedDict
 
 from django.core.files.base import ContentFile
 from django.core.management.base import BaseCommand, CommandParser
-from home.models import HomePage
+try:
+    from ...models import HomePage
+except ImportError:  # pragma: no cover
+    from home.models import HomePage
 from PIL import Image as PILImage
 from PIL import ImageDraw, ImageFont
 from sum_core.branding.models import SiteSettings

--- a/boilerplate/requirements.txt
+++ b/boilerplate/requirements.txt
@@ -11,3 +11,9 @@ sum-core @ git+https://github.com/markashton480/sum-core.git@v0.6.0#subdirectory
 
 # PostgreSQL driver for production deployments
 psycopg[binary]>=3.2,<4
+
+# Required by Django's Redis cache backend
+redis>=5,<6
+
+# WSGI server (used by typical systemd + Caddy deploy)
+gunicorn>=22,<24

--- a/cli/sum_cli/boilerplate/project_name/home/management/commands/seed_sage_stone.py
+++ b/cli/sum_cli/boilerplate/project_name/home/management/commands/seed_sage_stone.py
@@ -14,7 +14,11 @@ from typing import Any, TypedDict
 
 from django.core.files.base import ContentFile
 from django.core.management.base import BaseCommand, CommandParser
-from home.models import HomePage
+
+try:
+    from ...models import HomePage
+except ImportError:  # pragma: no cover
+    from home.models import HomePage
 from PIL import Image as PILImage
 from PIL import ImageDraw, ImageFont
 from sum_core.branding.models import SiteSettings

--- a/cli/sum_cli/boilerplate/requirements.txt
+++ b/cli/sum_cli/boilerplate/requirements.txt
@@ -11,3 +11,9 @@ sum-core @ git+https://github.com/markashton480/sum-core.git@v0.6.0#subdirectory
 
 # PostgreSQL driver for production deployments
 psycopg[binary]>=3.2,<4
+
+# Required by Django's Redis cache backend
+redis>=5,<6
+
+# WSGI server (used by typical systemd + Caddy deploy)
+gunicorn>=22,<24


### PR DESCRIPTION
Closes #323

- Fix `seed_sage_stone` HomePage import so packaged client projects can run the seeder.
- Add missing production deps to generated client requirements: `redis` (Django Redis cache backend) and `gunicorn` (systemd unit).

Tested: `pytest -q tests/test_seed_sage_stone_command.py::test_seed_sage_stone_creates_site_and_homepage cli/tests/test_theme_init.py::test_init_includes_seed_sage_stone_command`