### PR TITLE
docs(ops): log staging HTTPS redirect + DNS gotchas

### DIFF
--- a/docs/ops-pack/what-broke-last-time.md
+++ b/docs/ops-pack/what-broke-last-time.md
@@ -137,9 +137,14 @@
 
 **Date:** 2025-12-29  
 **Version:** N/A → v0.6.0  
-**Symptom:** Initial staging deploy failed due to missing client production deps (`gunicorn`, `redis`) and the `seed_sage_stone` command importing `HomePage` from `home.models` (breaks packaged projects where the app is `<project>.home`).  
-**Fix:** Added `gunicorn` + `redis` to client requirements and updated the seeder to use a packaged import with a fallback for file-path-loaded tests; re-deployed and re-ran seeding.  
-**Follow-up:** Ensure boilerplate requirements include production deps used by our runbooks/scripts; add a deploy preflight check that verifies `gunicorn` is present and health is checked over HTTPS.
+**Symptom:** Initial staging deploy failed due to missing client production deps (`gunicorn`, `redis`) and a seeder import bug:
+
+- systemd: `sum-sage-and-stone-gunicorn.service` failed with `status=203/EXEC` because `/srv/sum/sage-and-stone/venv/bin/gunicorn` did not exist (gunicorn not installed in venv).
+- seeder: `python manage.py seed_sage_stone ...` raised `ModuleNotFoundError: No module named 'home'` because the command imported `HomePage` from `home.models` (breaks packaged projects where the app is `<project>.home`).
+- cache: during seeding, Wagtail cache operations raised `ModuleNotFoundError: No module named 'redis'` when using `django.core.cache.backends.redis.RedisCache` without the `redis` Python client installed.
+
+**Fix:** Added `gunicorn` + `redis` to client requirements; updated `seed_sage_stone` to use a packaged import with a safe fallback for file-path-loaded tests; re-deployed, enabled gunicorn, and re-ran seeding.  
+**Follow-up:** Ensure boilerplate requirements include production deps used by our runbooks/scripts; add a deploy preflight check that verifies `gunicorn` is present and health is checked over HTTPS (and consider a quick import check for `redis` when Redis cache backend is configured).
 
 ---
 


### PR DESCRIPTION
Adds a Sage & Stone follow-up entry noting:
- `/admin/` HTTP->HTTPS redirect (308) can confuse smoke checks
- Use HTTPS to verify admin protection, and `curl --resolve` when local DNS isn't resolving
