### PR TITLE
docs: add development setup commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,13 @@ python manage.py runserver
 
 ## Development Setup
 
+Create and activate a virtual environment (recommended):
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
 Clone the repository and install the development tooling:
 
 ```bash


### PR DESCRIPTION
Adds a development setup section to the README with the standard make targets for local installs and checks. Fixes #332.