### PR TITLE
GH-514: Add Makefile test targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help lint test test-cli test-themes test-templates test-fast verify-source-intact format run migrate makemigrations install install-dev clean db-up db-down db-logs sync-cli-boilerplate check-cli-boilerplate release-check release-set-core-ref preflight
+.PHONY: help lint test test-integration test-full test-e2e test-cli test-themes test-templates test-fast verify-source-intact format run migrate makemigrations install install-dev clean db-up db-down db-logs sync-cli-boilerplate check-cli-boilerplate release-check release-set-core-ref preflight
 
 MANAGE = python core/sum_core/test_project/manage.py
 
@@ -28,8 +28,17 @@ format: ## Auto-format code
 	isort --settings-path pyproject.toml core cli tests
 
 
-test: ## Run tests with pytest
+test: ## Run fast tests (default, excludes slow/integration)
 	python -m pytest
+
+test-integration: ## Run integration/slow tests only
+	python -m pytest -m "slow or integration"
+
+test-full: ## Run all tests except E2E
+	python -m pytest -m "" --ignore=tests/e2e
+
+test-e2e: ## Run Playwright E2E tests
+	python -m pytest tests/e2e
 
 test-cli: ## Run CLI test slice only
 	python -m pytest cli/tests -q

--- a/docs/ops-pack/what-broke-last-time.md
+++ b/docs/ops-pack/what-broke-last-time.md
@@ -46,6 +46,16 @@
 
 ## Site: sum-platform (Core)
 
+**Date:** 2026-01-03  
+**Version:** v0.7.1-dev  
+**Symptom:** `make lint` failed locally with `make: mypy: No such file or directory`, and `make test` failed with `/usr/bin/python: No module named pytest`.  
+**Fix:** Install dev dependencies (e.g., `make install-dev`) and ensure the `.venv` is active before running lint/tests.  
+**Follow-up:** Add a quick environment check in onboarding docs or Make targets to confirm `mypy`/`pytest` are installed.
+
+---
+
+## Site: sum-platform (Core)
+
 **Date:** 2025-12-25
 **Version:** v0.7.1-dev
 **Symptom:** `make format` rewrote files inside `.venv/`. This started after `fix(THEME-016-A)` (commit `8bc2a00b`) changed `format` to `black --exclude '(?:^|/)(boilerplate|clients)/' .` + `isort .`. Passing `--exclude` overrides Black's default excludes (including `.venv`), so running at repo root started touching dot-directories.


### PR DESCRIPTION
## Summary
- add tiered Makefile test targets (fast/integration/full/e2e)
- document local lint/test dependency gaps in ops log

## Testing
- make lint (fails: mypy not installed)
- make test (fails: pytest not installed)

Closes #514
