### PR TITLE
chore: rename root package to sum-platform v0.7.1-dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,9 +3,9 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "sum-core"
-version = "0.6.0"
-description = "SUM core package and tooling (platform monorepo)"
+name = "sum-platform"
+version = "0.7.1-dev"
+description = "SUM Platform development monorepo"
 requires-python = ">=3.12"
 dependencies = []
 


### PR DESCRIPTION
## Summary

Root `pyproject.toml` incorrectly identified as `sum-core` version `0.6.0`. This is the platform monorepo, not the pip package (which lives in `core/sum_core/`).

## Changes

- `name`: `sum-core` → `sum-platform`
- `version`: `0.6.0` → `0.7.1-dev`
- `description`: Updated to "SUM Platform development monorepo"

## Context

Adopts the version convention that agents have been using in `docs/ops-pack/what-broke-last-time.md` entries. Formalizes their self-appointed versioning scheme.

## Testing

- `make lint` ✓ (toml check passes)