### PR TITLE
fix(pytest): remove coverage from default test config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,10 +103,6 @@ addopts = [
     "-m",
     "not slow and not integration",
     "--verbose",
-    "--cov=.",
-    "--cov-report=term-missing",
-    "--cov-report=term-missing",
-    "--cov-report=html",
     "--ignore=tests/e2e",
 ]
 pythonpath = ["core", "core/sum_core/test_project", "cli"]


### PR DESCRIPTION
## Summary

Removes coverage flags from default pytest `addopts` that were causing significant performance overhead.

## Problem

Coverage was running on every `make test` invocation:
- **2-3x overhead** from pytest-cov instrumentation
- Tests timing out after 5+ minutes (should be ~2 min)
- Codex agents hitting CI timeouts on seeder work

### Evidence

From Codex_B's diagnostics:
```
pytest tests/ --collect-only 2>&1 | head -50
...
coverage: platform linux, python 3.12.9-final-0
Using --random-order-seed=1181899
...
1181/1292 tests collected (111 deselected)
```

Coverage was always running even for basic test runs.

## Fix

Removed from `[tool.pytest.ini_options]` addopts:
- `--cov=.`
- `--cov-report=term-missing` (was duplicated!)
- `--cov-report=html`

Coverage can still be run explicitly:
```bash
pytest --cov=. --cov-report=term-missing
```

## Verification

After this change, `make test` should complete in ~2 minutes instead of timing out.

## Related

- VD #508 (Scale Infrastructure)
- Affects: SEED-02 work (Codex_B timing out)

false