### PR TITLE
GH-545: Document seeder architecture

### DIFF
--- a/docs/HANDBOOK.md
+++ b/docs/HANDBOOK.md
@@ -635,6 +635,9 @@ To cut a release properly, follow these steps exactly:
 | ----------- | ---------------------------------- | --------------------------------------------- |
 | **Dev**     | `make lint`                        | Ruff, Pyrefly, Black, and Isort checks        |
 | **Dev**     | `make test`                        | Run fast tests (default tier)                 |
+| **Seeder**  | `python manage.py seed <profile>`  | Seed site from YAML content profile           |
+| **Seeder**  | `python manage.py seed <profile> --clear` | Clear existing content and re-seed     |
+| **Seeder**  | `python manage.py seed <profile> --dry-run` | Validate and preview without writing |
 | **Release** | `make release-check`               | Pre-flight checks before tagging              |
 | **CLI**     | `sum init <slug> --theme <theme>`  | Scaffold a new client project with theme      |
 | **CLI**     | `sum check`                        | Verify environment and core wiring            |

--- a/docs/dev/CREATING-CONTENT-PROFILES.md
+++ b/docs/dev/CREATING-CONTENT-PROFILES.md
@@ -1,0 +1,484 @@
+# Creating Content Profiles
+
+A content profile is a collection of YAML files that define a complete site's content. This guide walks through creating a new profile from scratch.
+
+---
+
+## Directory Structure
+
+Create a new directory under `content/` with your profile name:
+
+```
+content/
+└── my-brand/
+    ├── site.yaml           # Required: Brand configuration
+    ├── navigation.yaml     # Required: Header/footer navigation
+    └── pages/              # Required: Page content directory
+        ├── home.yaml       # Required: Homepage
+        ├── about.yaml      # Recommended
+        ├── services.yaml   # Recommended
+        ├── portfolio.yaml  # Optional
+        ├── blog.yaml       # Optional
+        ├── contact.yaml    # Recommended
+        └── legal.yaml      # Recommended
+```
+
+The profile name should be lowercase with hyphens (e.g., `my-brand`, `acme-plumbing`).
+
+---
+
+## site.yaml
+
+Defines brand configuration, contact info, colors, and typography.
+
+### Required Fields
+
+```yaml
+# Company identity
+company_name: "My Brand"
+tagline: "Your tagline here"
+
+# Contact information
+phone_number: "+44 123 456 7890"
+email: "hello@mybrand.com"
+address: |
+  123 Main Street
+  London EC1A 1BB
+```
+
+### Optional Fields
+
+```yaml
+# Additional company info
+established_year: 2020
+business_hours: |
+  Monday - Friday: 9am - 5pm
+  Saturday: By appointment
+  Sunday: Closed
+
+# Colors (hex values)
+primary_color: "#1A2F23"
+secondary_color: "#4A6350"
+accent_color: "#A0563B"
+background_color: "#F7F5F1"
+text_color: "#1A2F23"
+surface_color: "#EDE8E0"
+surface_elevated_color: "#FFFFFF"
+text_light_color: "#5A6E5F"
+
+# Typography
+heading_font: "Playfair Display"
+body_font: "Lato"
+
+# Social media URLs
+instagram_url: "https://instagram.com/mybrand"
+facebook_url: ""
+linkedin_url: ""
+twitter_url: ""
+youtube_url: ""
+tiktok_url: ""
+
+# Analytics
+gtm_container_id: ""
+ga_measurement_id: ""
+
+# Cookie banner
+cookie_banner_enabled: false
+```
+
+### Field Aliases
+
+The seeder accepts common aliases for convenience:
+
+| Alias | Maps To |
+|-------|---------|
+| `phone` | `phone_number` |
+| `instagram` | `instagram_url` |
+| `facebook` | `facebook_url` |
+| `primary` | `primary_color` |
+| `secondary` | `secondary_color` |
+| `accent` | `accent_color` |
+| `background` | `background_color` |
+
+---
+
+## navigation.yaml
+
+Defines the header menu and footer sections.
+
+### Header Navigation
+
+```yaml
+header:
+  # Phone number visibility
+  show_phone_in_header: true
+
+  # Header CTA button
+  header_cta_enabled: true
+  header_cta_text: "Contact Us"
+  header_cta_link:
+    - type: "link"
+      value:
+        link_type: "page"
+        page: "contact"        # References page by slug
+        link_text: "Contact Us"
+
+  # Mobile CTA configuration
+  mobile_cta_enabled: true
+  mobile_cta_phone_enabled: true
+  mobile_cta_button_enabled: true
+  mobile_cta_button_text: "Enquire"
+  mobile_cta_button_link:
+    - type: "link"
+      value:
+        link_type: "page"
+        page: "contact"
+        link_text: "Enquire"
+
+  # Main menu items
+  menu_items:
+    - type: "item"
+      value:
+        label: "About"
+        link:
+          link_type: "page"
+          page: "about"
+          link_text: "About"
+        children: []
+
+    - type: "item"
+      value:
+        label: "Services"
+        link:
+          link_type: "page"
+          page: "services"
+          link_text: "Services"
+        children:
+          - label: "Service A"
+            link:
+              link_type: "url"
+              url: "/services/#service-a"
+              link_text: "Service A"
+          - label: "Service B"
+            link:
+              link_type: "url"
+              url: "/services/#service-b"
+              link_text: "Service B"
+```
+
+### Footer Navigation
+
+```yaml
+footer:
+  tagline: "Your tagline here."
+  auto_service_areas: false
+  copyright_text: "© {year} My Brand Ltd. All rights reserved."
+
+  # Social links (override site.yaml if needed)
+  social_instagram: "https://instagram.com/mybrand"
+  social_facebook: ""
+  social_linkedin: ""
+  social_youtube: ""
+  social_x: ""
+
+  # Footer sections
+  link_sections:
+    - type: "section"
+      value:
+        title: "Company"
+        links:
+          - link_type: "page"
+            page: "about"
+            link_text: "About Us"
+          - link_type: "page"
+            page: "contact"
+            link_text: "Contact"
+
+    - type: "section"
+      value:
+        title: "Legal"
+        links:
+          - link_type: "url"
+            url: "/privacy/"
+            link_text: "Privacy Policy"
+          - link_type: "url"
+            url: "/terms/"
+            link_text: "Terms of Service"
+
+    - type: "section"
+      value:
+        title: "Contact"
+        links:
+          - link_type: "email"
+            email: "hello@mybrand.com"
+            link_text: "hello@mybrand.com"
+          - link_type: "phone"
+            phone: "+44 123 456 7890"
+            link_text: "+44 123 456 7890"
+```
+
+### Link Types
+
+| Type | Fields | Example |
+|------|--------|---------|
+| `page` | `page` (slug) | `{"link_type": "page", "page": "about"}` |
+| `url` | `url` | `{"link_type": "url", "url": "/services/"}` |
+| `anchor` | `anchor` | `{"link_type": "anchor", "anchor": "contact-form"}` |
+| `email` | `email` | `{"link_type": "email", "email": "hello@site.com"}` |
+| `phone` | `phone` | `{"link_type": "phone", "phone": "+44123456"}` |
+
+---
+
+## Page YAML Files
+
+Each page file defines the content for a single page.
+
+### Required Fields
+
+Every page YAML must include:
+
+```yaml
+title: "Page Title"
+slug: "page-slug"
+```
+
+### Optional Metadata
+
+```yaml
+seo_title: "SEO Title | Brand Name"
+search_description: "Meta description for search engines."
+show_in_menus: true
+```
+
+### Body Content
+
+The `body` field contains a list of StreamField blocks:
+
+```yaml
+body:
+  - type: "hero_image"
+    value:
+      headline: "Welcome"
+      subheadline: "Your intro text here."
+      image: HERO_IMAGE
+      ctas:
+        - label: "Learn More"
+          url: "/about/"
+          style: "primary"
+
+  - type: "rich_text"
+    value: "<p>Your content here.</p>"
+
+  - type: "service_cards"
+    value:
+      heading: "Our Services"
+      cards:
+        - title: "Service A"
+          description: "<p>Description here.</p>"
+          image: SERVICE_A
+```
+
+### Block Types
+
+Reference the [Block Catalog](blocks-reference.md) for all available block types and their fields.
+
+Common blocks:
+
+| Block Type | Purpose |
+|------------|---------|
+| `hero_image` | Full-width hero with background image |
+| `hero_gradient` | Hero with gradient background |
+| `rich_text` | HTML content |
+| `service_cards` | Grid of service cards |
+| `testimonials` | Customer testimonials |
+| `faq` | Accordion FAQ section |
+| `contact_form` | Contact form block |
+| `stats` | Statistics display |
+| `portfolio` | Portfolio gallery |
+| `team_grid` | Team member grid |
+
+---
+
+## Image Keys
+
+Reference images by key in your YAML. The seeder generates placeholder images automatically.
+
+### Using Image Keys
+
+```yaml
+hero:
+  image: HERO_IMAGE    # Will be resolved to a WagtailImage
+
+cards:
+  - title: "Card 1"
+    image: SERVICE_A   # Another image key
+```
+
+### Standard Image Keys
+
+The following keys are pre-defined in the image manifest:
+
+| Key | Dimensions | Purpose |
+|-----|------------|---------|
+| `HERO_IMAGE` | 1920x1080 | Main hero background |
+| `SURREY_IMAGE` | 1000x700 | Featured project |
+| `WORKSHOP_IMAGE` | 1200x800 | Workshop/behind-the-scenes |
+| `FOUNDER_IMAGE` | 800x1000 | Founder portrait |
+| `TEAM_*` | 400x500 | Team member portraits |
+| `SERVICE_*` | 600x400 | Service illustrations |
+| `PORTFOLIO_*` | 800x600 | Portfolio images |
+| `BLOG_*` | 1200x600 | Blog featured images |
+| `DETAIL_*` | 600x600 | Detail/gallery images |
+| `LOGO_*` | 200x80 | Certification logos |
+
+### Custom Image Keys
+
+You can use any key name. The seeder generates a placeholder if the key isn't in the manifest:
+
+```yaml
+hero:
+  image: MY_CUSTOM_IMAGE  # Will generate a generic placeholder
+```
+
+---
+
+## Interpolation
+
+Use `${path.to.value}` syntax to reference values from other parts of the profile:
+
+```yaml
+# In site.yaml
+company_name: "My Brand"
+tagline: "Quality you can trust"
+
+# In navigation.yaml
+footer:
+  tagline: "${tagline}"  # Resolves to "Quality you can trust"
+```
+
+### Available Context
+
+| Path | Source |
+|------|--------|
+| `site.*` | Values from site.yaml |
+| `navigation.*` | Values from navigation.yaml |
+| `pages.*` | Page data (by filename) |
+| Top-level keys | Direct values from site.yaml |
+
+---
+
+## Validation
+
+The ContentLoader validates your YAML files:
+
+### Required Structure
+
+- `site.yaml` must be a non-empty mapping
+- `navigation.yaml` must be a non-empty mapping
+- Each page YAML must have `slug` and `title` fields
+
+### Common Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| `Profile not found` | Directory doesn't exist | Check path and spelling |
+| `Required content file missing` | Missing site.yaml or navigation.yaml | Create the required file |
+| `YAML root must be a mapping` | File contains a list/scalar | Ensure file starts with key-value pairs |
+| `Page missing valid slug` | Page lacks slug field | Add `slug: "page-slug"` |
+| `Interpolation path not found` | Invalid `${}` reference | Check the reference path exists |
+
+---
+
+## Testing Your Profile
+
+### Dry Run
+
+Validate your profile without writing to the database:
+
+```bash
+python manage.py seed my-brand --dry-run
+```
+
+This prints the seed plan:
+
+```
+Seed plan
+  Profile: my-brand
+  Content dir: /path/to/content
+  Pages:
+    - home
+    - about
+    - services
+    - contact
+  Seeders:
+    - home
+    - about
+    - services
+    - contact
+```
+
+### Full Seed
+
+Seed your profile:
+
+```bash
+# Clear existing and seed fresh
+python manage.py seed my-brand --clear
+
+# Or update existing content
+python manage.py seed my-brand
+```
+
+### Verify in Admin
+
+1. Open Wagtail Admin at `/admin/`
+2. Navigate to Pages and verify structure
+3. Check Settings > Site Settings for branding
+4. Check Settings > Header/Footer Navigation
+
+---
+
+## Example: Minimal Profile
+
+Here's a minimal profile with just the required files:
+
+### content/minimal/site.yaml
+
+```yaml
+company_name: "Minimal Brand"
+tagline: "Keep it simple"
+phone_number: "+44 123 456 7890"
+email: "hello@minimal.com"
+address: "123 Simple Street"
+```
+
+### content/minimal/navigation.yaml
+
+```yaml
+header:
+  show_phone_in_header: true
+  header_cta_enabled: false
+  menu_items: []
+
+footer:
+  tagline: "Keep it simple."
+  link_sections: []
+```
+
+### content/minimal/pages/home.yaml
+
+```yaml
+title: "Home"
+slug: "home"
+body:
+  - type: "rich_text"
+    value: "<h1>Welcome</h1><p>This is a minimal site.</p>"
+```
+
+---
+
+## See Also
+
+- [Seeder Architecture](SEEDER-ARCHITECTURE.md) — Technical overview
+- [Block Reference](blocks-reference.md) — Available block types
+- [Sage & Stone Profile](../user/seed-sage-stone.md) — Complete example profile

--- a/docs/dev/SEEDER-ARCHITECTURE.md
+++ b/docs/dev/SEEDER-ARCHITECTURE.md
@@ -1,0 +1,351 @@
+# Seeder Architecture
+
+The SUM Platform uses a modular seeder system that separates content definitions (YAML) from seeding logic (Python). This architecture enables:
+
+- **Reusable seeders**: Write seeding logic once, use it with multiple content profiles.
+- **Declarative content**: Define site content in YAML files, not Python code.
+- **Extensibility**: Add new page types by registering new seeders.
+- **Testability**: Test seeding logic independently of content.
+
+---
+
+## Directory Structure
+
+```
+sum-platform/
+├── seeders/                    # Seeder infrastructure (Python modules)
+│   ├── __init__.py             # Public API exports
+│   ├── base.py                 # BaseSeeder, SeederRegistry, helpers
+│   ├── content.py              # ContentLoader, ProfileData
+│   ├── exceptions.py           # Custom exception classes
+│   ├── images.py               # ImageManager, placeholder generation
+│   ├── orchestrator.py         # SeedOrchestrator, SeedPlan, SeedResult
+│   ├── site.py                 # SiteSeeder (branding, navigation)
+│   └── pages/                  # Page-specific seeders
+│       ├── __init__.py
+│       ├── home.py             # HomePageSeeder
+│       ├── about.py            # AboutPageSeeder
+│       ├── services.py         # ServicesPageSeeder
+│       ├── portfolio.py        # PortfolioPageSeeder
+│       ├── blog.py             # BlogPageSeeder
+│       ├── contact.py          # ContactPageSeeder
+│       ├── legal.py            # LegalPageSeeder
+│       ├── standard.py         # StandardPageSeeder
+│       └── utils.py            # Shared utilities
+│
+├── content/                    # YAML content profiles
+│   └── sage-stone/             # Example profile
+│       ├── site.yaml           # Brand config, colors, contact info
+│       ├── navigation.yaml     # Header/footer navigation structure
+│       └── pages/              # Page content
+│           ├── home.yaml
+│           ├── about.yaml
+│           ├── services.yaml
+│           ├── portfolio.yaml
+│           ├── blog.yaml
+│           ├── contact.yaml
+│           └── legal.yaml
+│
+└── core/sum_core/test_project/
+    └── home/management/commands/
+        └── seed.py             # Management command (thin wrapper)
+```
+
+---
+
+## Core Concepts
+
+### Content Profiles
+
+A **content profile** is a directory under `content/` containing YAML files that define a complete site's content. Each profile includes:
+
+| File | Purpose |
+|------|---------|
+| `site.yaml` | Brand configuration (company info, colors, typography, social links) |
+| `navigation.yaml` | Header menu structure and footer sections |
+| `pages/*.yaml` | Individual page content (one file per page) |
+
+### The Orchestrator
+
+The `SeedOrchestrator` coordinates the entire seeding process:
+
+1. Loads content from a profile via `ContentLoader`
+2. Discovers and initializes page seeders from the registry
+3. Generates placeholder images via `ImageManager`
+4. Seeds pages in dependency order
+5. Seeds site-level configuration (branding, navigation)
+
+```python
+from seeders import SeedOrchestrator
+
+orchestrator = SeedOrchestrator()
+orchestrator.seed("sage-stone", clear=True)
+```
+
+### Page Seeders
+
+Page seeders are registered with `SeederRegistry` and handle specific page types:
+
+```python
+from seeders import BaseSeeder, SeederRegistry
+
+@SeederRegistry.register("about")
+class AboutPageSeeder(BaseSeeder):
+    def seed(self, content: dict, clear: bool = False) -> None:
+        # Create or update the about page
+        pass
+
+    def clear(self) -> None:
+        # Remove seeded content
+        pass
+```
+
+### Dependency Injection
+
+The orchestrator injects dependencies into seeders that declare them:
+
+```python
+class MySeeder(BaseSeeder):
+    def __init__(
+        self,
+        *,
+        content_loader: ContentLoader,  # Injected automatically
+        image_manager: ImageManager,    # Injected automatically
+    ) -> None:
+        self.content_loader = content_loader
+        self.image_manager = image_manager
+```
+
+---
+
+## Public API
+
+### Exports from `seeders`
+
+```python
+from seeders import (
+    # Core classes
+    BaseSeeder,
+    SeederRegistry,
+    ContentLoader,
+    ProfileData,
+    SeedOrchestrator,
+    SeedPlan,
+    SeedResult,
+    SiteSeeder,
+    ImageManager,
+
+    # Helper functions
+    create_child_page,
+    generate_slug,
+    get_or_create_page,
+    publish_page,
+
+    # Exceptions
+    SeederError,
+    SeederContentError,
+    SeederPageError,
+    SeederNotFoundError,
+    SeederRegistrationError,
+    SeederRegistryError,
+    SeederSlugError,
+    ContentProfileError,
+    ContentSchemaError,
+)
+```
+
+### SeedOrchestrator
+
+The main entry point for seeding operations.
+
+#### Constructor
+
+```python
+SeedOrchestrator(
+    content_dir: Path | None = None,      # Override content directory
+    content_loader: ContentLoader | None = None,
+    image_manager: ImageManager | None = None,
+    image_manifest: Iterable[ImageSpec] | None = None,
+    image_prefix: str = "SEED",           # Prefix for generated image titles
+    page_order: Iterable[str] | None = None,  # Override page seeding order
+    page_seeder_classes: dict | None = None,  # Override seeder registry
+    site_seeder_class: type = SiteSeeder,
+    auto_discover: bool = True,           # Auto-discover page seeders
+)
+```
+
+#### Methods
+
+| Method | Description |
+|--------|-------------|
+| `list_profiles()` | Returns list of available profile names |
+| `plan(profile)` | Returns a `SeedPlan` without writing data |
+| `seed(profile, clear=False, dry_run=False)` | Seeds a profile; returns `SeedPlan` or `SeedResult` |
+
+### ContentLoader
+
+Loads and validates YAML content profiles.
+
+```python
+loader = ContentLoader(content_dir=Path("content"))
+profiles = loader.list_profiles()  # ["sage-stone"]
+data = loader.load_profile("sage-stone")  # ProfileData
+```
+
+### ProfileData
+
+Container for loaded profile content:
+
+```python
+@dataclass(frozen=True)
+class ProfileData:
+    site: dict[str, Any]           # Contents of site.yaml
+    navigation: dict[str, Any]     # Contents of navigation.yaml
+    pages: dict[str, dict]         # {page_name: page_content}
+```
+
+### ImageManager
+
+Generates and caches placeholder images.
+
+```python
+manager = ImageManager(prefix="SEED")
+image = manager.generate("HERO_IMAGE", 1920, 1080, label="Hero Kitchen")
+images = manager.generate_manifest(IMAGE_MANIFEST)
+```
+
+---
+
+## Management Command
+
+The `seed` management command provides CLI access to the orchestrator.
+
+### Usage
+
+```bash
+# Seed with default profile (sage-stone if available)
+python manage.py seed
+
+# Seed a specific profile
+python manage.py seed sage-stone
+
+# Clear existing content before seeding
+python manage.py seed sage-stone --clear
+
+# Override content directory
+python manage.py seed sage-stone --content-path ./my-content
+
+# Dry run (validate and print plan without writing)
+python manage.py seed sage-stone --dry-run
+```
+
+### Options
+
+| Option | Description |
+|--------|-------------|
+| `profile` | Content profile name (optional if default exists) |
+| `--clear` | Delete existing seeded content before re-seeding |
+| `--content-path` | Override the content directory (default: `./content`) |
+| `--dry-run` | Validate content and print plan without writing |
+
+---
+
+## Seeding Flow
+
+```mermaid
+sequenceDiagram
+    participant Cmd as seed command
+    participant Orch as SeedOrchestrator
+    participant Loader as ContentLoader
+    participant Reg as SeederRegistry
+    participant Pages as Page Seeders
+    participant Site as SiteSeeder
+
+    Cmd->>Orch: seed(profile, clear)
+    Orch->>Loader: load_profile(profile)
+    Loader-->>Orch: ProfileData
+
+    Orch->>Orch: _discover_page_seeders()
+    Orch->>Reg: all()
+    Reg-->>Orch: registered seeders
+
+    Orch->>Orch: _generate_images()
+
+    loop For each page in order
+        Orch->>Pages: seed(content)
+        Pages-->>Orch: page object
+    end
+
+    Orch->>Site: seed(content)
+    Orch-->>Cmd: SeedResult
+```
+
+---
+
+## Page Order
+
+Pages are seeded in a defined order to ensure dependencies are met (e.g., home page exists before navigation references it). The default order is:
+
+1. home
+2. about
+3. services
+4. portfolio
+5. blog
+6. contact
+7. legal
+
+Pages not in this list are seeded alphabetically after the ordered pages.
+
+---
+
+## Image Keys
+
+YAML content can reference images by key. The orchestrator generates these images and passes them to seeders:
+
+```yaml
+# In page YAML
+hero:
+  image: HERO_IMAGE  # References the image key
+```
+
+```python
+# In seeder
+image = images.get("HERO_IMAGE")  # WagtailImage object
+```
+
+Standard image keys are defined in `seeders/images.py`:
+
+| Key | Dimensions | Purpose |
+|-----|------------|---------|
+| `HERO_IMAGE` | 1920x1080 | Main hero background |
+| `LOGO` | 300x80 | Header/footer logo |
+| `FAVICON` | 64x64 | Browser favicon |
+| `FOUNDER_IMAGE` | 800x1000 | Team portraits |
+| `SERVICE_*` | 600x400 | Service illustrations |
+| `PORTFOLIO_*` | 800x600 | Portfolio images |
+| `BLOG_*` | 1200x600 | Blog featured images |
+
+---
+
+## Relationship to Legacy Seeders
+
+The modular seeder system replaces the monolithic `seed_sage_stone.py` command. Key differences:
+
+| Aspect | Legacy | Modular |
+|--------|--------|---------|
+| Content | Hardcoded in Python | YAML files |
+| Structure | Single 3,000+ line file | Multiple focused modules |
+| Reusability | Copy and modify | Register and configure |
+| Testing | Full integration only | Unit test individual seeders |
+
+### Migration Path
+
+The legacy `seed_sage_stone` command has been replaced by `seed sage-stone`. Both produce the same site structure; the modular version reads content from `content/sage-stone/`.
+
+---
+
+## See Also
+
+- [Creating Content Profiles](CREATING-CONTENT-PROFILES.md) — Guide to creating new profiles
+- [Extending Seeders](extending-seeders.md) — Legacy patterns (still valid for custom commands)
+- [Sage & Stone Seeder](../user/seed-sage-stone.md) — User documentation

--- a/docs/dev/extending-seeders.md
+++ b/docs/dev/extending-seeders.md
@@ -2,6 +2,12 @@
 
 Guide for creating additional site seeders based on the Sage & Stone patterns.
 
+> **Note**: This document covers the legacy monolithic seeder pattern. For the new modular seeder architecture with YAML content profiles, see:
+> - [Seeder Architecture](SEEDER-ARCHITECTURE.md) — Technical overview of the modular system
+> - [Creating Content Profiles](CREATING-CONTENT-PROFILES.md) — Guide to creating YAML content profiles
+>
+> The new `python manage.py seed <profile>` command uses `SeedOrchestrator` and registered page seeders. The patterns below remain valid for creating custom standalone seeder commands.
+
 ## Overview
 
 Seeders are Django management commands that populate a Wagtail site with demo content. They follow consistent patterns for idempotency, configurability, and content structure.
@@ -427,5 +433,7 @@ def test_full_seed_workflow(wagtail_default_site):
 
 ## See Also
 
+- [Seeder Architecture](SEEDER-ARCHITECTURE.md) — Modular seeder system documentation
+- [Creating Content Profiles](CREATING-CONTENT-PROFILES.md) — YAML content profile guide
 - [Sage & Stone Seeder](../user/seed-sage-stone.md) — Reference implementation
 - [Theme Guide](THEME-GUIDE.md) — Block types and templates


### PR DESCRIPTION
## Summary

Document the new modular seeder architecture for developers and maintainers.

### Deliverables

- [x] `docs/dev/SEEDER-ARCHITECTURE.md` — Technical overview of the modular seeder system including:
  - Directory structure (`seeders/`, `content/`)
  - Core concepts (content profiles, orchestrator, page seeders, dependency injection)
  - Public API documentation (`SeedOrchestrator`, `ContentLoader`, `ProfileData`, etc.)
  - Management command usage
  - Seeding flow diagram
  - Page order and image keys

- [x] `docs/dev/CREATING-CONTENT-PROFILES.md` — Guide for creating new site profiles:
  - Directory structure for a new profile
  - YAML schema for `site.yaml`, `navigation.yaml`, `pages/*.yaml`
  - Image key conventions
  - Link types and interpolation syntax
  - Validation and testing

- [x] `docs/HANDBOOK.md` — Added seeder commands to Major Commands table:
  - `python manage.py seed <profile>`
  - `python manage.py seed <profile> --clear`
  - `python manage.py seed <profile> --dry-run`

- [x] `docs/dev/extending-seeders.md` — Updated with references to new docs and note about `SeedOrchestrator`

## Testing

- `make lint` ✓ (ruff passes; pyrefly has pre-existing Makefile issue)
- `make test` ✓ (1273 passed, 10 skipped)

Closes #545

🤖 Generated with [Claude Code](https://claude.com/claude-code)