### PR TITLE
GH-579: Create sum-themes repo

### DIFF
--- a/docs/dev/THEME-GUIDE.md
+++ b/docs/dev/THEME-GUIDE.md
@@ -58,6 +58,10 @@ SUM Platform themes are **structure-first**. The premium feel comes from archite
 └─────────────────────────────────────────────────────────────┘
 ```
 
+### Theme Distribution Repository
+
+Theme sources are published to `markashton480/sum-themes` for versioned distribution and client consumption. Treat `sum-platform/themes/` as the source of truth during development, and only sync to the distribution repo when the publishing workflow says so.
+
 ### Key Files You'll Create
 
 | File | Purpose |


### PR DESCRIPTION
Docs: 

- Document the distribution repo location in the theme guide
- Clarify source-of-truth expectations during theme development

Closes #579